### PR TITLE
Fix/english only

### DIFF
--- a/Engine/StreamStorm/api/validation.py
+++ b/Engine/StreamStorm/api/validation.py
@@ -22,13 +22,13 @@ class StormData(BaseModel):
     
     model_config = ConfigDict(strict=True) 
     
-    video_url: str = Field(..., description="Video url", validation_alias=AliasChoices("video_url","videoUrl"))
-    chat_url: str = Field(... , description="Chat url", validation_alias=AliasChoices("chat_url","chatUrl"))
+    video_url: str = Field(..., description="Video url", validation_alias=AliasChoices("video_url", "videoUrl"))
+    chat_url: str = Field(... , description="Chat url", validation_alias=AliasChoices("chat_url", "chatUrl"))
     messages: list[str] = Field(..., description="Message list")
     subscribe: bool = Field(... , description="Subscribe flag")
-    subscribe_and_wait: bool = Field(..., description="Subscribe and wait flag", validation_alias=AliasChoices("subscribe_and_wait","subscribeAndWait"))
-    subscribe_and_wait_time: StrictInt = Field(... , ge=0, description="Subscribe and wait time in seconds", validation_alias=AliasChoices("subscribe_and_wait_time","subscribeAndWaitTime"))
-    slow_mode: int = Field(... , ge=1, description="Slow mode time in seconds", validation_alias=AliasChoices("slow_mode","slowMode"))
+    subscribe_and_wait: bool = Field(..., description="Subscribe and wait flag", validation_alias=AliasChoices("subscribe_and_wait", "subscribeAndWait"))
+    subscribe_and_wait_time: StrictInt = Field(... , ge=0, description="Subscribe and wait time in seconds", validation_alias=AliasChoices("subscribe_and_wait_time", "subscribeAndWaitTime"))
+    slow_mode: int = Field(... , ge=1, description="Slow mode time in seconds", validation_alias=AliasChoices("slow_mode", "slowMode"))
     channels: list[int] = Field(... , description="Channels")
     background: bool = Field(... , description="Background flag")
 
@@ -113,7 +113,7 @@ class ChangeMessagesData(BaseModel):
         return value
     
 class ChangeSlowModeData(BaseModel):
-    slow_mode: int = Field(..., description="New slow mode value", ge=1, validation_alias=AliasChoices("slow_mode","slowMode"))
+    slow_mode: int = Field(..., description="New slow mode value", ge=1, validation_alias=AliasChoices("slow_mode", "slowMode"))
     
     @field_validator("slow_mode")
     def validate_slow_mode(cls, value: int) -> int:

--- a/Engine/StreamStorm/core/BrowserAutomator.py
+++ b/Engine/StreamStorm/core/BrowserAutomator.py
@@ -3,28 +3,38 @@ from abc import ABC, abstractmethod
 class BrowserAutomator(ABC):
 
     @abstractmethod
-    async def open_browser(self) -> None:
+    def open_browser(self) -> None:
         """Open a browser and navigate to the specified URL."""
         pass
 
     @abstractmethod
-    async def go_to_page(self, url: str) -> None:
+    def go_to_page(self, url: str) -> None:
         """Navigate to the specified URL."""
         pass
 
     @abstractmethod
-    async def find_and_click_element(self, *args, **kwargs) -> None:
+    def find_and_click_element(self, *args, **kwargs) -> None:
         """Find an element and click it."""
         pass
 
     @abstractmethod
-    async def find_element(self, *args, **kwargs) -> None:
+    def find_element(self, *args, **kwargs) -> None:
         """Find an element on the page."""
         pass
 
     @abstractmethod
-    async def type_and_enter(self, *args, **kwargs) -> None:
+    def type_and_enter(self, *args, **kwargs) -> None:
         """Type a message into a text field and press enter."""
+        pass
+    
+    @abstractmethod
+    def check_language_english(self) -> None:
+        """Check if the language of the page is English."""
+        pass
+    
+    @abstractmethod
+    def change_language(self) -> None:
+        """Change the language of the browser to English."""
         pass
     
 

--- a/Engine/StreamStorm/core/Playwright.py
+++ b/Engine/StreamStorm/core/Playwright.py
@@ -93,6 +93,16 @@ class Playwright(BrowserAutomator):
         except Exception as _:
             self.__instance_alive = False
             logger.info(f"[{self.index}] [{self.channel_name}] : ##### StreamStorm instance marked as dead by: Failure to attach error listeners")
+            
+    async def check_language_english(self) -> bool:
+        language: str = await self.page.evaluate("navigator.language")        
+        
+        if language.startswith("en-"): 
+            return True  
+        
+    def change_language(self):
+        raise NotImplementedError
+    
 
     async def open_browser(self) -> None:
         self.playwright: AsyncPlaywright = await async_playwright().start()

--- a/Engine/StreamStorm/core/Playwright.py
+++ b/Engine/StreamStorm/core/Playwright.py
@@ -97,8 +97,7 @@ class Playwright(BrowserAutomator):
     async def check_language_english(self) -> bool:
         language: str = await self.page.evaluate("navigator.language")        
         
-        if language.startswith("en-"): 
-            return True  
+        return language.startswith("en-")
         
     def change_language(self):
         raise NotImplementedError

--- a/Engine/StreamStorm/core/Selenium.py
+++ b/Engine/StreamStorm/core/Selenium.py
@@ -1,3 +1,4 @@
+import re
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -37,17 +38,16 @@ class Selenium(BrowserAutomator):
                 self.driver.execute_script("arguments[0].scrollIntoView();", element)
             element.click()
 
-        except (ElementNotInteractableException, ElementNotFound):
+        except (ElementNotInteractableException, ElementNotFound) as e:
             if not for_subscribe and not for_profiles_init:
                 self.driver.close()
-                raise BrowserClosedError    
+                raise BrowserClosedError from e
             
     def check_language_english(self) -> bool:
         html_tag: WebElement = self.find_element(By.TAG_NAME, "html")
         language: str = html_tag.get_attribute("lang")
         
-        if language.startswith("en-"): 
-            return True   
+        return language.startswith("en-") 
     
     def change_language(self):
         raise NotImplementedError

--- a/Engine/StreamStorm/core/Selenium.py
+++ b/Engine/StreamStorm/core/Selenium.py
@@ -3,6 +3,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import ElementNotInteractableException
+from selenium.webdriver.common.by import By
 
 from ..utils.exceptions import BrowserClosedError, ElementNotFound
 from .BrowserAutomator import BrowserAutomator
@@ -31,17 +32,26 @@ class Selenium(BrowserAutomator):
 
         try:
             element: WebElement = self.find_element(by, value, wait_time=5 if for_profiles_init else 15)
-            
+
             if scroll:
                 self.driver.execute_script("arguments[0].scrollIntoView();", element)
             element.click()
-            
+
         except (ElementNotInteractableException, ElementNotFound):
-            if for_subscribe or for_profiles_init:
-                pass
-            else:
-                self.driver.close()  
-                raise BrowserClosedError       
+            if not for_subscribe and not for_profiles_init:
+                self.driver.close()
+                raise BrowserClosedError    
+            
+    def check_language_english(self) -> bool:
+        html_tag: WebElement = self.find_element(By.TAG_NAME, "html")
+        language: str = html_tag.get_attribute("lang")
+        
+        if language.startswith("en-"): 
+            return True   
+    
+    def change_language(self):
+        raise NotImplementedError
+    
         
     async def open_browser(self):
         """

--- a/Engine/StreamStorm/core/SeparateInstance.py
+++ b/Engine/StreamStorm/core/SeparateInstance.py
@@ -23,6 +23,10 @@ class SeparateInstance(Playwright):
         self.index: int = index
         self.__instance_alive: bool = True
         self.__logged_in: Optional[bool] = None
+        
+        
+    async def change_language(self):
+        self.go_to_page("https://www.youtube.com/account?hl=en-US&persist_hl=1")             
 
 
     async def login(self) -> bool:        
@@ -34,7 +38,13 @@ class SeparateInstance(Playwright):
             
             await self.go_to_page("https://www.youtube.com/account") # We are going to account page because it loads faster than the main page
             
+            english: bool = await self.check_language_english()            
+            
+            if not english:
+                await self.change_language()
+                
             await self.find_and_click_element('//*[@id="avatar-btn"]', 'avatar_button') # Click on avatar button
+            
             
             await self.find_and_click_element("//*[text()='Switch account']", 'switch_account_button') # Click on switch account button
 

--- a/Engine/StreamStorm/core/StreamStorm.py
+++ b/Engine/StreamStorm/core/StreamStorm.py
@@ -48,29 +48,29 @@ class StreamStorm(Profiles): # removed Selenium inheritance coz its doing nothin
     ) -> None:
         
         super().__init__()
-        
-        self.url: str = url
-        self.chat_url: str = chat_url
+
+        self.url: str = f"{url}?hl=en-US&persist_hl=1"
+        self.chat_url: str = f"{chat_url}?hl=en-US&persist_hl=1"
         self.messages: list[str] = messages
         self.subscribe: tuple[bool, bool] = subscribe
         self.subscribe_and_wait_time: int = subscribe_and_wait_time
         self.slow_mode: int = slow_mode
         self.channels: list[int] = sorted(channels)
         self.background: bool = background
-        
+
         self.ready_event: Event = Event()
         self.pause_event: Event = Event()
         self.run_stopper_event: Event = Event()
-        
+
         self.total_instances: int = len(channels)
         self.ready_to_storm_instances: int = 0
         self.total_channels: int = 0
         self.all_channels: dict[str, dict[str, str]] = {}
-        
+
         self.assigned_profiles: dict[str, int] = {}
-        
+
         StreamStorm.ss_instance = self
-        
+
         logger.debug(f"StreamStorm initialized with url: {self.url}, channels: {self.channels}, "
                     f"messages count: {len(self.messages)}, slow_mode: {self.slow_mode}s, "
                     f"background: {self.background}")        

--- a/Engine/StreamStorm/core/StreamStorm.py
+++ b/Engine/StreamStorm/core/StreamStorm.py
@@ -49,8 +49,8 @@ class StreamStorm(Profiles): # removed Selenium inheritance coz its doing nothin
         
         super().__init__()
 
-        self.url: str = f"{url}?hl=en-US&persist_hl=1"
-        self.chat_url: str = f"{chat_url}?hl=en-US&persist_hl=1"
+        self.url: str = f"{url}&hl=en-US&persist_hl=1"
+        self.chat_url: str = f"{chat_url}&hl=en-US&persist_hl=1"
         self.messages: list[str] = messages
         self.subscribe: tuple[bool, bool] = subscribe
         self.subscribe_and_wait_time: int = subscribe_and_wait_time

--- a/Engine/StreamStorm/core/UndetectedDrivers.py
+++ b/Engine/StreamStorm/core/UndetectedDrivers.py
@@ -56,13 +56,20 @@ class UndetectedDrivers(Selenium):
 
         logger.debug(f"Browser PID: {self.driver.browser_pid}")
 
+
     def get_total_channels(self) -> None:
         
         with suppress(NoSuchElementException, ElementNotInteractableException):
             # select first channel if popup appears
             self.find_and_click_element(By.XPATH, "//ytd-popup-container//*[@id='contents']/ytd-account-item-renderer[1]", for_profiles_init=True)
+            
+        english: bool = self.check_language_english()
+        
+        if not english: 
+            self.driver.get("https://www.youtube.com/account?hl=en-US&persist_hl=1")
         
         self.find_and_click_element(By.XPATH, '//*[@id="avatar-btn"]')
+        
         self.find_and_click_element(By.XPATH, "//*[text()='Switch account']")
 
         WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.XPATH, "//*[@id='submenu']//*[@id='container']//*[@id='contents']//*[@id='contents']/ytd-account-item-renderer")))

--- a/Engine/tests/api/test_on_storm_data_instantiation.py
+++ b/Engine/tests/api/test_on_storm_data_instantiation.py
@@ -43,8 +43,8 @@ def test_storm_data_instantiated(client: TestClient):
     response = client.post("/storm/start", json=payload)
     assert response.status_code == 200
     
-    assert StreamStorm.ss_instance.url == video_url
-    assert StreamStorm.ss_instance.chat_url == chat_url
+    assert StreamStorm.ss_instance.url == f"{video_url}?hl=en-US&persist_hl=1"
+    assert StreamStorm.ss_instance.chat_url == f"{chat_url}?hl=en-US&persist_hl=1"
     assert StreamStorm.ss_instance.messages == messages
     assert StreamStorm.ss_instance.subscribe == (subscribe, subscribe_and_wait)
     assert StreamStorm.ss_instance.subscribe_and_wait_time == subscribe_and_wait_time

--- a/Engine/tests/api/test_on_storm_data_instantiation.py
+++ b/Engine/tests/api/test_on_storm_data_instantiation.py
@@ -43,8 +43,8 @@ def test_storm_data_instantiated(client: TestClient):
     response = client.post("/storm/start", json=payload)
     assert response.status_code == 200
     
-    assert StreamStorm.ss_instance.url == f"{video_url}?hl=en-US&persist_hl=1"
-    assert StreamStorm.ss_instance.chat_url == f"{chat_url}?hl=en-US&persist_hl=1"
+    assert StreamStorm.ss_instance.url == f"{video_url}&hl=en-US&persist_hl=1"
+    assert StreamStorm.ss_instance.chat_url == f"{chat_url}&hl=en-US&persist_hl=1"
     assert StreamStorm.ss_instance.messages == messages
     assert StreamStorm.ss_instance.subscribe == (subscribe, subscribe_and_wait)
     assert StreamStorm.ss_instance.subscribe_and_wait_time == subscribe_and_wait_time

--- a/UI/src/context/StormDataContext.jsx
+++ b/UI/src/context/StormDataContext.jsx
@@ -94,7 +94,7 @@ const StormDataProvider = ({ children }) => {
 
         getStormData: () => {
             return {
-                videoURL,
+                videoUrl: videoURL,
                 chatUrl: "https://www.youtube.com/live_chat?v=" + videoURL.split('v=')[1],
                 messages,
                 subscribe,


### PR DESCRIPTION
Closes #83

## Summary by Sourcery

Enforce English-only interactions by detecting page language, redirecting to English URLs, and adding corresponding methods in browser automators, while refactoring abstract method signatures and adjusting tests and UI context naming.

New Features:
- Add language detection and enforcement for English in Selenium and Playwright automators
- Append `?hl=en-US&persist_hl=1` parameters to video and chat URLs to enforce English locale

Bug Fixes:
- Correct video URL key naming in StormDataContext from videoURL to videoUrl

Enhancements:
- Convert BrowserAutomator abstract methods from async to synchronous signatures
- Simplify exception handling in Selenium find_and_click_element

Tests:
- Update API instantiation test to expect English locale parameters in generated URLs